### PR TITLE
PubMed refences - now with abstracts and titles

### DIFF
--- a/templates/pubmeds.html
+++ b/templates/pubmeds.html
@@ -1,0 +1,4 @@
+{% for pub in pubmeds %}
+	{{pub.title}} </br>
+	{{pub.abstract}} </br> </br>
+{% endfor %}

--- a/templates/snplist.html
+++ b/templates/snplist.html
@@ -48,7 +48,7 @@
 			</br>
 			</br>
 			{% for snp in snps %}
-				<ul class="pills"><li><a href="/dbsnp/?snp={{snp}}" target="info">{{snp}}</a></li></ul>
+				<ul class="pills"><li><a href="/dbsnp/?snp={{snp.snpid}}" target="info">{{snp.snpid}}</a></li></ul>
 			{% endfor %}
 		</div>
 


### PR DESCRIPTION
class pubmed now returns a list of dicts with {title, abstract, id} of each article
- plus a small change to ioanas template to make at reference data from the database
- added a simple template for presenting each pubmed article

[#26374687 close]
