### PR TITLE
EPIC GWAS IMPORT ERROR

### DIFF
--- a/Util.py
+++ b/Util.py
@@ -36,7 +36,7 @@ def AddStudyDocument(study):
     doc = search.Document(doc_id=study.pubmed_id, # Treat pubmed_id as key
         fields=[
             search.TextField(name='name', value=study.name),
-            # search.TextField(name='disease_trait', value=study.diseases),
+            search.TextField(name='disease_trait', value=','.join([s.name for s in study.diseases])),
             search.TextField(name='id', value=study.pubmed_id)
             ])
     search.Index(name=study._index).add(doc)

--- a/Util.py
+++ b/Util.py
@@ -32,14 +32,14 @@ def AddDiseaseDocument(d):
     search.Index(name=d._index).add(doc)
 
 
-# def AddStudyDocument(study):
-#     doc = search.Document(doc_id=study.pubmed_id, # Treat pubmed_id as key
-#         fields=[
-#             search.TextField(name='name', value=study.name),
-#             search.TextField(name='disease_trait', value=study.diseases),
-#             search.TextField(name='id', value=study.pubmed_id)
-#             ])
-#     search.Index(name=study._index).add(doc)
+def AddStudyDocument(study):
+    doc = search.Document(doc_id=study.pubmed_id, # Treat pubmed_id as key
+        fields=[
+            search.TextField(name='name', value=study.name),
+            # search.TextField(name='disease_trait', value=study.diseases),
+            search.TextField(name='id', value=study.pubmed_id)
+            ])
+    search.Index(name=study._index).add(doc)
 
 def AddSNPDocument(snp):
     doc = search.Document(
@@ -109,7 +109,7 @@ def populate(path="gwascatalog.txt", limit=100):
     i = 0
     for pid, lines in pubids.iteritems():
         i += 1
-        if i == 200:
+        if i == 100:
             break
         print i
         # create a new study object for each new iteration
@@ -128,7 +128,7 @@ def populate(path="gwascatalog.txt", limit=100):
         study.repl_sample= init["Replication Sample Size"].strip()
         study.platform = init["Platform [SNPs passing QC]"].strip()
         study.put()
-        # AddStudyDocument(study)
+        AddStudyDocument(study)
 
         disease_name = None
         disease = None

--- a/controllers/gwasController.py
+++ b/controllers/gwasController.py
@@ -26,7 +26,7 @@ class diseaseList(AppRequestHandler):
         rendered = memcache.get("diseaselist_0:50")
         if rendered is None:
             # make large query, to check for speed when cached
-            diseases = Disease.all()
+            diseases = Disease.all().fetch(100)
             # generate only the bare-bones list of diseases, ignore everything from base.html etc.
             rendered = self.render("diseaselistrender.html", diseases=diseases, filter=filter)
 
@@ -51,9 +51,14 @@ class diseaseView(AppRequestHandler):
         if rendered is None:
             # make large query, to check for speed when cached
             disease = db.get(db.Key.from_path("Disease", name))
+            studies = db.get(disease.studies)
+            if studies is None:
+                logging.info("ERRRRRRROR: no studies!")
+            else:
+                logging.info("%s" % studies)
 
             # generate only the bare-bones list of diseases, ignore everything from base.html etc.
-            rendered = self.render("diseaseview.html", disease=disease)
+            rendered = self.render("diseaseview.html", disease=disease, studies=studies)
 
             # add to memchache
             if not memcache.set(name, rendered, namespace="disease"):
@@ -77,7 +82,7 @@ class studyList(AppRequestHandler):
         rendered = memcache.get("studylist_0:50")
         if rendered is None:
             # make large query, to check for speed when cached
-            studies = Study.all().fetch(50)
+            studies = Study.all().fetch(100)
             rendered = self.render("studylistrender.html",studies=studies, filter=filter)
             # logging.debug(rendered )
             # add to memchache

--- a/controllers/gwasController.py
+++ b/controllers/gwasController.py
@@ -104,7 +104,7 @@ class studyView(AppRequestHandler):
         self.out(study=study)
 
     # Comment on a study via POST
-    def get(self, pubmed_id):
+    def post(self, pubmed_id):
         self.setTemplate('studyview.html')
         study = Study.get_by_key_name(pubmed_id)
         if study is None:
@@ -144,7 +144,6 @@ class genePresenter(AppRequestHandler):
     _template = 'gene.html'
     def get(self, gene):
         gene = Gene.gql("WHERE name = :1", gene).get()
-
         self.out(gene=gene)
 
     # Comment on a gene via POST

--- a/controllers/gwasController.py
+++ b/controllers/gwasController.py
@@ -95,15 +95,21 @@ class studyList(AppRequestHandler):
 
 class studyView(AppRequestHandler):
     """View a particular study"""
-    def get(self, i):
+    def get(self, pubmed_id):
         self.setTemplate('studyview.html')
-        study = Study.gql("WHERE pubmed_id = :1", i).get()
+        study = Study.get_by_key_name(pubmed_id)
+        if study is None:
+            self.redirect('/studies/')
+            return
         self.out(study=study)
 
     # Comment on a study via POST
-    def post(self, i):
+    def get(self, pubmed_id):
         self.setTemplate('studyview.html')
-        study = Study.gql("WHERE pubmed_id = :1", i).get()
+        study = Study.get_by_key_name(pubmed_id)
+        if study is None:
+            self.redirect('/studies/')
+            return
 
         comment = Comment()
         comment.study = study.key()

--- a/models/study.py
+++ b/models/study.py
@@ -4,9 +4,16 @@ from models.Application import AppModel
 class Disease(AppModel):
     """For viewing a unique list of diseases, we need a disease to be a relation and not just a textfield"""
     name = db.StringProperty(required=True)
-
-
+    studies = db.ListProperty(db.Key)
     _index = 'Diseases'
+
+    @property
+    def add_study(self, study_key):
+        # add study as relation only if it's not already in the list
+        if study_key not in self.studies:
+            self.studies.append(study_key)
+            self.put()
+
 
 # PK = pubmed_id
 class Study(AppModel):
@@ -20,7 +27,8 @@ class Study(AppModel):
     # 6 - description of study
     name = db.StringProperty(required=True)
     # 7 disease or trait researched
-    disease_ref = db.ReferenceProperty(Disease, required=True, collection_name="studies")
+    # disease_ref = db.ReferenceProperty(Disease, required=True, collection_name="studies")
+    diseases = db.ListProperty(db.Key) # keys to diseases
     # to prevent relation traversal
     disease_trait = db.StringProperty(required=True)
 
@@ -31,6 +39,17 @@ class Study(AppModel):
     repl_sample = db.StringProperty()
     platform = db.StringProperty()
     
+    @property
+    def add_disease(self, disease_name):
+        # realation between disease and study is a many_to_many
+        # - this helps make sure that is kept when importing
+        # add disease to diseases attribute and add this study to the disease
+        disease = Disease.get_or_insert(disease_name)
+        if disease.key() not in self.diseases:
+            self.diseases.append(disease.key())
+            self.put()
+        disease.add_study(self.key())
+
     @property
     def genes(self):
         return Gene.gql("WHERE studies = :1", self.key())

--- a/models/study.py
+++ b/models/study.py
@@ -7,7 +7,7 @@ class Disease(AppModel):
     studies = db.ListProperty(db.Key)
     _index = 'Diseases'
 
-    @property
+    # @property
     def add_study(self, study_key):
         # add study as relation only if it's not already in the list
         if study_key not in self.studies:
@@ -30,7 +30,7 @@ class Study(AppModel):
     # disease_ref = db.ReferenceProperty(Disease, required=True, collection_name="studies")
     diseases = db.ListProperty(db.Key) # keys to diseases
     # to prevent relation traversal
-    disease_trait = db.StringProperty(required=True)
+    # disease_trait = db.StringProperty(required=True)
 
     abstract = db.StringProperty()
     # 8 - antal forsogspersoner
@@ -39,12 +39,11 @@ class Study(AppModel):
     repl_sample = db.StringProperty()
     platform = db.StringProperty()
     
-    @property
-    def add_disease(self, disease_name):
+    # @property
+    def add_disease(self, disease):
         # realation between disease and study is a many_to_many
         # - this helps make sure that is kept when importing
         # add disease to diseases attribute and add this study to the disease
-        disease = Disease.get_or_insert(disease_name)
         if disease.key() not in self.diseases:
             self.diseases.append(disease.key())
             self.put()

--- a/templates/diseaselistrender.html
+++ b/templates/diseaselistrender.html
@@ -1,4 +1,6 @@
-<h2>Diseases</h2>
+<div class="page-header">
+    <h2>Diseases</h2>
+</div>
 {% for disease in diseases %}
 <article class="row">
     <div class="span10">

--- a/templates/diseaseview.html
+++ b/templates/diseaseview.html
@@ -1,4 +1,16 @@
-<h2>Disease: {{disease.name}}</h2>
+<ul class="breadcrumb">
+  <li>
+    <a href="/diseases/">Diseases</a> <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/disease/{{disease.name}}">{{disease.name}}</a>
+  </li>
+</ul>
+
+<div class="page-header">
+    <h2>{{disease.name}}</h2>
+</div>
+
 {% for study in studies %}
 <h3>{{study}}</h3>
 <article class="row">

--- a/templates/diseaseview.html
+++ b/templates/diseaseview.html
@@ -1,5 +1,6 @@
 <h2>Disease: {{disease.name}}</h2>
-{% for study in disease.studies %}
+{% for study in studies %}
+<h3>{{study}}</h3>
 <article class="row">
     <time class="span1">{{study.date}}</time>
     <div class="span10">

--- a/templates/gene.html
+++ b/templates/gene.html
@@ -6,14 +6,13 @@ Gene Details
 {% block content %}
 {% if gene %}
 <h1>{{gene.name}}</h1>
-
 <table class="table table-striped">
     <thead><th><h1><small>Referenced by</small></h1></th><th><h1><small>Correlated with</small></h1></th></thead>
     <tbody>
         {% for gwas in gene.gwas %}
         <tr>
             <td><a href="/study/{{gwas.study.pubmed_id}}">{{gwas.study.name}}</a></td>
-            <td>{{gwas.study.disease_trait}}</td>
+            <td>{{gwas.disease.name}}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/templates/studylistrender.html
+++ b/templates/studylistrender.html
@@ -1,14 +1,15 @@
 <h2>Studies</h2>
 {% for study in studies %}
-<article class="row">
+<article class="row-fluid">
     <time class="span1">{{study.date}}</time>
-    <div class="span10">
-        {% for disease in study.diseases %}
-            <h3>{{disease.name()}}</h3>
-        {% else %}
-            <h3>No disease relations</h3>
-        {% endfor %}
+    <div class="span11">
     <h3><small>{{study.name}}</small></h3>
+    <h4>Disease(s):</h4>
+    <ul>
+            {% for disease in study.diseases %}
+                <li> <h4><a href="/disease/{{disease.name()}}">{{disease.name()}}</a></h4> </li>
+            {% endfor %}
+        </ul>
     <dl class="dl-horizontal">
         <dt>Sample size(s):</dt>
             <dd>{{study.init_sample}}</dd>

--- a/templates/studylistrender.html
+++ b/templates/studylistrender.html
@@ -3,7 +3,11 @@
 <article class="row">
     <time class="span1">{{study.date}}</time>
     <div class="span10">
-    <h3>{{study.disease_trait}}</h3>
+        {% for disease in study.diseases %}
+            <h3>{{disease.name()}}</h3>
+        {% else %}
+            <h3>No disease relations</h3>
+        {% endfor %}
     <h3><small>{{study.name}}</small></h3>
     <dl class="dl-horizontal">
         <dt>Sample size(s):</dt>

--- a/templates/studylistrender.html
+++ b/templates/studylistrender.html
@@ -1,27 +1,27 @@
 <h2>Studies</h2>
 {% for study in studies %}
 <article class="row-fluid">
-    <time class="span1">{{study.date}}</time>
+    <p class="span1">{{study.date}}</p>
     <div class="span11">
-    <h3><small>{{study.name}}</small></h3>
-    <h4>Disease(s):</h4>
-    <ul>
-            {% for disease in study.diseases %}
-                <li> <h4><a href="/disease/{{disease.name()}}">{{disease.name()}}</a></h4> </li>
-            {% endfor %}
+        <h3><small>{{study.name}}</small></h3>
+        <h4>Disease(s):</h4>
+        <ul>
+        {% for disease in study.diseases %}
+            <li> <h4><a href="/disease/{{disease.name()}}">{{disease.name()}}</a></h4> </li>
+        {% endfor %}
         </ul>
-    <dl class="dl-horizontal">
-        <dt>Sample size(s):</dt>
-            <dd>{{study.init_sample}}</dd>
-        <dt>Replication sample:</dt>
-            <dd>{{study.repl_sample}}</dd>
-        <dt>Platform</dt>
-            <dd> {{study.platform}}</dd>
-    </dl>
-    <p><a href="/study/{{study.pubmed_id}}" class="btn btn-mini">
-        Study #{{study.pubmed_id}}</a>
-        <a href="{{study.pubmed_url}}" class="btn btn-mini">View on pubmed</a>
-    </p>
+        <dl class="dl-horizontal">
+            <dt>Sample size(s):</dt>
+                <dd>{{study.init_sample}}</dd>
+            <dt>Replication sample:</dt>
+                <dd>{{study.repl_sample}}</dd>
+            <dt>Platform</dt>
+                <dd> {{study.platform}}</dd>
+        </dl>
+        <p><a href="/study/{{study.pubmed_id}}" class="btn btn-mini">
+            Study #{{study.pubmed_id}}</a>
+            <a href="{{study.pubmed_url}}" class="btn btn-mini">View on pubmed</a>
+        </p>
     </div>
 </article>
 {% else %}

--- a/templates/studyview.html
+++ b/templates/studyview.html
@@ -1,21 +1,29 @@
 {% extends "base.html" %}
 {% block title %}
-Study Details: {{study.name}}
+Study - {{study.name}}
 {% endblock %}
 
 {% block content %}
-    <article class="row-fluid">
+<ul class="breadcrumb">
+  <li>
+    <a href="/studies/">Studies</a> <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/study/{{study.key().name()}}">{{study.name}}</a>
+  </li>
+</ul>
+<article class="row-fluid">
         <!-- <time class="span1">{{study.date}}</time> -->
         <div class="span12">
         <div class="page-header">
-            <h2>Study <br> <small>{{study.name}}</small> </h2>
+            <h3>{{study.name}}</h3>
         </div>
         <h3>Disease(s):</h3>
         <ul>
             {% for disease in study.diseases %}
-                <li><a href="/disease/{{disease.name()}}">{{disease.name()}}</a></li>
+                <li> <h4><a href="/disease/{{disease.name()}}">{{disease.name()}}</a></h4> </li>
             {% endfor %}
-            </ul>
+        </ul>
         <dl class="dl-horizontal">
             <dt>Sample size(s):</dt>
                 <dd>{{study.init_sample}}</dd>
@@ -63,8 +71,7 @@ Study Details: {{study.name}}
         </table>
         {% endif %}
         </div>
-    </article>
-
+</article>
 {% block comments %}
 {% set comments = study.comments %}
 {% include 'comments.html' %}

--- a/templates/studyview.html
+++ b/templates/studyview.html
@@ -4,15 +4,18 @@ Study Details: {{study.name}}
 {% endblock %}
 
 {% block content %}
-    <article class="row">
-        <time class="span1">{{study.date}}</time>
-        <div class="span10">
-        {% for disease in study.diseases %}
-            <h3>{{disease.name()}}</h3>
-        {% else %}
-            <h3>No realted diseases</h3>
-        {% endfor %}
-        <h3><small>{{study.name}}</small></h3>
+    <article class="row-fluid">
+        <!-- <time class="span1">{{study.date}}</time> -->
+        <div class="span12">
+        <div class="page-header">
+            <h2>Study <br> <small>{{study.name}}</small> </h2>
+        </div>
+        <h3>Disease(s):</h3>
+        <ul>
+            {% for disease in study.diseases %}
+                <li><a href="/disease/{{disease.name()}}">{{disease.name()}}</a></li>
+            {% endfor %}
+            </ul>
         <dl class="dl-horizontal">
             <dt>Sample size(s):</dt>
                 <dd>{{study.init_sample}}</dd>

--- a/templates/studyview.html
+++ b/templates/studyview.html
@@ -7,7 +7,11 @@ Study Details: {{study.name}}
     <article class="row">
         <time class="span1">{{study.date}}</time>
         <div class="span10">
-        <h3>{{study.disease_trait}}</h3>
+        {% for disease in study.diseases %}
+            <h3>{{disease.name()}}</h3>
+        {% else %}
+            <h3>No realted diseases</h3>
+        {% endfor %}
         <h3><small>{{study.name}}</small></h3>
         <dl class="dl-horizontal">
             <dt>Sample size(s):</dt>


### PR DESCRIPTION
I've been having fevery dreams these last couple of weeks, and I suddenly realized why. The import used one idiotic assumption when loading the GWAS. That each study only references a **single** disease. This, in retrospect, is obviously not the case, given that multiple GWAS correlations could possibly be identified in a study.

This means that each study now has a list of diseases they reference, instead of just one, and each disease now has many more studies to reference (possibly).

In other words, there is actually a many-to-many relationship between disease and study, whereas the old model only had a one disease to many studies relation.
- added disease <*----*> study relation
- updated templates to reflect this model change
- study no longer has a `study.disease_ref` but an array of keys

Since this fix obviously has implications on how we search for studies, I wanted to give @wejendorp a heads up. Since the "disease_trait" field is no longer there, replaced by an array of disease_keys  (I could add an additional disease_names string-array if that would simplify things?), you can no longer index the disease-field of the study. For now I've simply commented out that field in your indexing, and I couldn't figure out how to add indexing for arrays.
