### PR TITLE
Fixed links to diseases from gene-view

### DIFF
--- a/templates/gene.html
+++ b/templates/gene.html
@@ -12,7 +12,7 @@ Gene Details
         {% for gwas in gene.gwas %}
         <tr>
             <td><a href="/study/{{gwas.study.pubmed_id}}">{{gwas.study.name}}</a></td>
-            <td>{{gwas.disease.name}}</td>
+            <td><a href="/disease/{{gwas.disease.name}}">{{gwas.disease.name}}</a></td>
         </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
now the geneview.html page has a working link back to the disease that's referenced by it
